### PR TITLE
refactored order function

### DIFF
--- a/functions/__tests__/index.spec.js
+++ b/functions/__tests__/index.spec.js
@@ -50,8 +50,8 @@ describe('firebase-functions', () => {
       await orders(req, res);
       expect(res.status).toHaveBeenCalledWith(405);
       expect(res.json).toHaveBeenCalledWith({
-        message: 'method not allowed',
-        details: 'provided method: GET',
+        message: 'request method GET not allowed',
+        status: 405,
       });
     });
 
@@ -60,7 +60,10 @@ describe('firebase-functions', () => {
       await orders(req, res);
       expect(logger.error).toHaveBeenCalledWith('no symbol provided');
       expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith({ message: 'symbol is required' });
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'symbol is required',
+        status: 400,
+      });
     });
 
     it('should return 400 if side is missing', async () => {
@@ -68,7 +71,10 @@ describe('firebase-functions', () => {
       await orders(req, res);
       expect(logger.error).toHaveBeenCalledWith('no side provided');
       expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith({ message: 'side is required' });
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'side is required',
+        status: 400,
+      });
     });
 
     it('should return 400 if buying power is insufficient', async () => {
@@ -79,6 +85,7 @@ describe('firebase-functions', () => {
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith({
         message: 'insufficient buying power',
+        status: 400,
         value: 5,
       });
     });
@@ -95,8 +102,9 @@ describe('firebase-functions', () => {
       expect(res.status).toHaveBeenCalledWith(500);
       expect(res.json).toHaveBeenCalledWith({
         message: error.message,
-        block: 'getBuyingPower',
+        block: 'checkBuyingPower',
         error,
+        status: 500,
       });
     });
 

--- a/functions/src/checkBuyingPower.d.ts
+++ b/functions/src/checkBuyingPower.d.ts
@@ -1,0 +1,27 @@
+export = checkBuyingPower;
+declare function checkBuyingPower(): Promise<
+  | {
+      status: number;
+      message: string;
+      value: number;
+      block?: undefined;
+      error?: undefined;
+      buying_power?: undefined;
+    }
+  | {
+      status: number;
+      message: any;
+      block: string;
+      error: unknown;
+      value?: undefined;
+      buying_power?: undefined;
+    }
+  | {
+      buying_power: number;
+      status?: undefined;
+      message?: undefined;
+      value?: undefined;
+      block?: undefined;
+      error?: undefined;
+    }
+>;

--- a/functions/src/checkBuyingPower.js
+++ b/functions/src/checkBuyingPower.js
@@ -1,0 +1,33 @@
+const logger = require('firebase-functions/logger');
+const { getBuyingPower } = require('@alpaca-firebase/account');
+
+const checkBuyingPower = async () => {
+  let buyingPower;
+  try {
+    logger.info('starting getBuyingPower');
+    buyingPower = await getBuyingPower();
+    logger.info('available buying power:', buyingPower);
+    if (buyingPower <= 5) {
+      logger.warn('insufficient buying power');
+      return {
+        status: 400,
+        message: 'insufficient buying power',
+        value: buyingPower,
+      };
+    }
+  } catch (error) {
+    logger.error('error in getBuyingPower:', error);
+    return {
+      status: 500,
+      message: error.message,
+      block: 'checkBuyingPower',
+      error,
+    };
+  }
+
+  return {
+    buying_power: buyingPower,
+  };
+};
+
+module.exports = checkBuyingPower;

--- a/functions/src/validateRequest.d.ts
+++ b/functions/src/validateRequest.d.ts
@@ -1,0 +1,15 @@
+export = validateRequest;
+declare function validateRequest(req: any): Promise<
+  | {
+      status: number;
+      message: string;
+      symbol?: undefined;
+      side?: undefined;
+    }
+  | {
+      symbol: any;
+      side: any;
+      status?: undefined;
+      message?: undefined;
+    }
+>;

--- a/functions/src/validateRequest.js
+++ b/functions/src/validateRequest.js
@@ -1,0 +1,31 @@
+const logger = require('firebase-functions/logger');
+
+const validateRequest = async (req) => {
+  if (req.method !== 'POST') {
+    return {
+      status: 405,
+      message: `request method ${req.method} not allowed`,
+    };
+  }
+  logger.info('orders request body:', JSON.stringify(req.body));
+  const { body } = req;
+  const { symbol, side: direction } = body;
+  const side = direction?.toLowerCase();
+  if (!symbol) {
+    logger.error('no symbol provided');
+    return {
+      status: 400,
+      message: 'symbol is required',
+    };
+  }
+  if (!side) {
+    logger.error('no side provided');
+    return {
+      status: 400,
+      message: 'side is required',
+    };
+  }
+  return { symbol, side };
+};
+
+module.exports = validateRequest;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "predeploy": ".bin/set-env",
     "deploy": "firebase deploy",
     "build": ".bin/build",
-    "release": ".bin/release"
+    "release": ".bin/release",
+    "verify": ".bin/verify"
   },
   "repository": {
     "type": "git",

--- a/packages/helpers/index.d.ts
+++ b/packages/helpers/index.d.ts
@@ -6,6 +6,7 @@ export namespace constants {
   let MARKET: string;
   let GTC: string;
   let DAY: string;
+  let IOC: string;
   let BUY_TO_OPEN: string;
   let SELL_TO_CLOSE: string;
   let OPEN: string;

--- a/packages/helpers/index.js
+++ b/packages/helpers/index.js
@@ -12,6 +12,7 @@ const constants = {
   MARKET: 'market',
   GTC: 'gtc',
   DAY: 'day',
+  IOC: 'ioc',
   BUY_TO_OPEN: 'buy_to_open',
   SELL_TO_CLOSE: 'sell_to_close',
   OPEN: 'open',

--- a/packages/orders/__tests__/index.spec.js
+++ b/packages/orders/__tests__/index.spec.js
@@ -81,8 +81,8 @@ describe('orders', () => {
         side: 'buy',
         symbol: 'BTC/USD',
         type: 'market',
-        notional: 990,
-        time_in_force: 'day',
+        notional: 1000,
+        time_in_force: 'ioc',
         position_intent: 'buy_to_open',
       });
     });
@@ -104,8 +104,30 @@ describe('orders', () => {
       expect(alpaca.createOrder).toHaveBeenCalledWith({
         side: 'sell',
         type: 'market',
-        time_in_force: 'day',
+        time_in_force: 'ioc',
         symbol: 'BTC/USD',
+        position_intent: 'sell_to_close',
+        qty: 2,
+      });
+    });
+
+    it('should set time_in_force to `day` if the asset is not crypto', async () => {
+      const mockPosition = { qty: '2' };
+      const mockSnapshot = { midPrice: 500 };
+      const mockOrder = { id: 'order1' };
+      formatSymbol.mockReturnValue('SCHD');
+      getPositionForSymbol.mockResolvedValueOnce(mockPosition);
+      getCryptoSnapshot.mockResolvedValueOnce(mockSnapshot);
+      getMidPrice.mockReturnValueOnce(500);
+      alpaca.createOrder.mockResolvedValueOnce(mockOrder);
+
+      const order = await createSellOrder('SCHD');
+      expect(order).toEqual(mockOrder);
+      expect(alpaca.createOrder).toHaveBeenCalledWith({
+        side: 'sell',
+        type: 'market',
+        time_in_force: 'day',
+        symbol: 'SCHD',
         position_intent: 'sell_to_close',
         qty: 2,
       });
@@ -135,7 +157,26 @@ describe('orders', () => {
         side: 'buy',
         symbol: 'BTC/USD',
         type: 'market',
-        notional: 99,
+        notional: 100,
+        time_in_force: 'ioc',
+        position_intent: 'buy_to_open',
+      });
+    });
+    it('should set time_in_force to `day` if the asset is not crypto', async () => {
+      const mockOrder = { id: 'order1' };
+      formatSymbol.mockReturnValue('SCHD');
+      getBuyingPower.mockResolvedValueOnce(100);
+      getMidPrice.mockReturnValueOnce(10);
+      toDecimal.mockReturnValueOnce(9.9);
+      alpaca.createOrder.mockResolvedValueOnce(mockOrder);
+
+      const order = await createOrder('SCHD', 'buy');
+      expect(order).toEqual(mockOrder);
+      expect(alpaca.createOrder).toHaveBeenCalledWith({
+        side: 'buy',
+        symbol: 'SCHD',
+        type: 'market',
+        notional: 100,
         time_in_force: 'day',
         position_intent: 'buy_to_open',
       });
@@ -157,7 +198,7 @@ describe('orders', () => {
         symbol: 'BTC/USD',
         type: 'market',
         qty: 2,
-        time_in_force: 'day',
+        time_in_force: 'ioc',
         position_intent: 'sell_to_close',
       });
     });

--- a/packages/orders/index.js
+++ b/packages/orders/index.js
@@ -28,14 +28,14 @@ const closeOrdersForSymbol = async (symbol) => {
 };
 
 const createBuyOrder = async (symbol, config = {}) => {
-  const maxBuyingPower = await getBuyingPower();
-  const buyingPower = maxBuyingPower * 0.99;
+  const buyingPower = await getBuyingPower();
+  const timeInForce = /USD$/.test(symbol) ? constants.IOC : constants.DAY;
   const options = {
     side: constants.BUY,
     symbol: formatSymbol(symbol),
     type: constants.MARKET,
     notional: parseFloat(buyingPower.toFixed(2)),
-    time_in_force: constants.DAY,
+    time_in_force: timeInForce,
     position_intent: constants.BUY_TO_OPEN,
     ...config,
   };
@@ -50,10 +50,11 @@ const createSellOrder = async (symbol, config = {}) => {
     return null;
   }
   const qty = parseFloat(position.qty);
+  const timeInForce = /USD$/.test(symbol) ? constants.IOC : constants.DAY;
   const options = {
     side: constants.SELL,
     type: constants.MARKET,
-    time_in_force: constants.DAY,
+    time_in_force: timeInForce,
     symbol: formatSymbol(symbol),
     position_intent: constants.SELL_TO_CLOSE,
     qty,


### PR DESCRIPTION
- separate functions into separate files
- use all available buying power (instead of 99%)
- handle crypto orders with correct `time_in_force` value